### PR TITLE
[conf] prod 1 modification config

### DIFF
--- a/42/Dockerfile
+++ b/42/Dockerfile
@@ -1,6 +1,15 @@
+# Étape 1 : Build avec Maven
+FROM maven:3.9.2-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Étape 2 : Exécuter avec JDK slim
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY target/stage-42-0.0.1-SNAPSHOT.jar app.jar
-ENV PORT=10000
+COPY --from=build /app/target/stage-42-0.0.1-SNAPSHOT.jar app.jar
+
+ENV PORT=$PORT
 EXPOSE $PORT
-ENTRYPOINT ["java", "-jar", "app.jar", "--server.port=$PORT"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--server.port=${PORT}"]

--- a/42/src/main/resources/application.properties
+++ b/42/src/main/resources/application.properties
@@ -1,15 +1,16 @@
 spring.application.name=42
-server.port=9090
-app.client_id=u-s4t2af-23f031abd5ab1c7afcd6b43148ddd70b2ae20692602fb8c142f94fabb55b5373
-app.client_secret=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
-app.redirect_uri=http://localhost:9090/auth
+server.port=${PORT:9090}  # Render fournit la variable PORT automatiquement
 
-# Configuration certificat
+app.client_id=${CLIENT_ID}
+app.client_secret=${CLIENT_SECRET}
+app.redirect_uri=${REDIRECT_URI}
+
+# Configuration certificat (si ce sont des fichiers locaux inclus dans le JAR, laisse-les)
 certificate.logo=src/main/resources/static/pdf/logo.png
 certificate.tampon=src/main/resources/static/pdf/tampon.png
 certificate.signature.directeur=src/main/resources/static/pdf/signature_directeur.png
 certificate.signature.assistant=src/main/resources/static/pdf/signature_assistant.png
 certificate.responsable=SURREL Antony
-certificate.poste=Assistant P\u00E9dagogique et IT
+certificate.poste=Assistant Pédagogique et IT
 certificate.etablissement=42 ANTANANARIVO
 certificate.etablissement.adresse=Building Titan VI Zone Galaxy, Andraharo 101 Antananarivo


### PR DESCRIPTION
2025-09-10T07:09:12.531572549Z ==> It looks like we don't have access to your repo, but we'll try to clone it anyway. 2025-09-10T07:09:12.53159054Z ==> Cloning from https://github.com/mioraralevason/42TOOLS 2025-09-10T07:09:13.455076616Z ==> Checking out commit 7ba43d29df2d1dee2b2dcecc8d8d296065ab7664 in branch main 2025-09-10T07:09:14.844019784Z #1 [internal] load build definition from Dockerfile 2025-09-10T07:09:14.844057735Z #1 transferring dockerfile: 215B done 2025-09-10T07:09:14.844060826Z #1 DONE 0.0s
2025-09-10T07:09:14.844063076Z
2025-09-10T07:09:14.844065796Z #2 [internal] load metadata for docker.io/library/openjdk:17-jdk-slim 2025-09-10T07:09:15.895817948Z #2 ...
2025-09-10T07:09:15.895834639Z
2025-09-10T07:09:15.895837729Z #3 [auth] library/openjdk:pull render-prod/docker-mirror-repository/library/openjdk:pull token for us-west1-docker.pkg.dev 2025-09-10T07:09:15.895841049Z #3 DONE 0.0s
2025-09-10T07:09:16.046307643Z
2025-09-10T07:09:16.046330314Z #2 [internal] load metadata for docker.io/library/openjdk:17-jdk-slim 2025-09-10T07:09:19.152920782Z #2 DONE 4.4s
2025-09-10T07:09:19.152943213Z
2025-09-10T07:09:19.152948903Z #4 [internal] load .dockerignore 2025-09-10T07:09:19.152953253Z #4 transferring context: 2B done 2025-09-10T07:09:19.152957664Z #4 DONE 0.0s
2025-09-10T07:09:19.152961624Z
2025-09-10T07:09:19.152965844Z #5 [internal] load build context 2025-09-10T07:09:19.152973935Z #5 transferring context: 2B done 2025-09-10T07:09:19.152978875Z #5 DONE 0.0s
2025-09-10T07:09:19.152983005Z
2025-09-10T07:09:19.152988955Z #6 [2/3] WORKDIR /app 2025-09-10T07:09:19.152993625Z #6 CACHED
2025-09-10T07:09:19.152997746Z
2025-09-10T07:09:19.153003666Z #7 [3/3] COPY target/stage-42-0.0.1-SNAPSHOT.jar app.jar 2025-09-10T07:09:19.153008836Z #7 ERROR: failed to calculate checksum of ref gaidiv864ydofqy2jqr8mb84i::rcvgednl2es3o151x78y812y5: failed to walk /home/user/.local/tmp/buildkit-mount1619946389/target: lstat /home/user/.local/tmp/buildkit-mount1619946389/target: no such file or directory 2025-09-10T07:09:19.153015137Z
2025-09-10T07:09:19.153021107Z #8 [1/3] FROM docker.io/library/openjdk:17-jdk-slim@sha256:aaa3b3cb27e3e520b8f116863d0580c438ed55ecfa0bc126b41f68c3f62f9774 2025-09-10T07:09:19.153026597Z #8 resolve docker.io/library/openjdk:17-jdk-slim@sha256:aaa3b3cb27e3e520b8f116863d0580c438ed55ecfa0bc126b41f68c3f62f9774 0.0s done 2025-09-10T07:09:19.153031137Z #8 DONE 0.0s
2025-09-10T07:09:19.174704618Z ------
2025-09-10T07:09:19.174723849Z  > [3/3] COPY target/stage-42-0.0.1-SNAPSHOT.jar app.jar: 2025-09-10T07:09:19.174728829Z ------
2025-09-10T07:09:19.176257297Z Dockerfile:3
2025-09-10T07:09:19.176269997Z --------------------
2025-09-10T07:09:19.176274718Z    1 |     FROM openjdk:17-jdk-slim
2025-09-10T07:09:19.176278288Z    2 |     WORKDIR /app
2025-09-10T07:09:19.176282498Z    3 | >>> COPY target/stage-42-0.0.1-SNAPSHOT.jar app.jar
2025-09-10T07:09:19.176296309Z    4 |     ENV PORT=10000
2025-09-10T07:09:19.176300089Z    5 |     EXPOSE $PORT
2025-09-10T07:09:19.176303709Z --------------------
2025-09-10T07:09:19.176308269Z error: failed to solve: failed to compute cache key: failed to calculate checksum of ref gaidiv864ydofqy2jqr8mb84i::rcvgednl2es3o151x78y812y5: failed to walk /home/user/.local/tmp/buildkit-mount1619946389/target: lstat /home/user/.local/tmp/buildkit-mount1619946389/target: no such file or directory
2025-09-10T07:09:19.189780484Z error: exit status 1